### PR TITLE
JSON parsing: use the '-r' option of jq instead of sed

### DIFF
--- a/pls
+++ b/pls
@@ -18,9 +18,12 @@ response=$(curl -s https://api.openai.com/v1/chat/completions \
   "messages": [{"role": "system", "content": "You are a helpful assistant. You will generate '$SHELL' commands based on user input. Your response should contain ONLY the command and NO explanation. Do NOT ever use newlines to seperate commands, instead use ; or &&. The current working directory is '$cwd'."}, {"role": "user", "content": "'"$args"'"}]
 }')
 
-# echo the 'content' field of the response which is in JSON format
+# parse the 'content' field of the response which is in JSON format
+command=$(echo $response | jq -r '.choices[0].message.content')
+
+# echo the command
 echo -e -n "\033[0;31m" # set color to red
-echo $response | jq '.choices[0].message.content' | sed -e 's/^.//' -e 's/.$//'
+echo $command
 
 # make the user confirm the command
 echo -e -n "\033[0;34m" # set color to blue
@@ -40,7 +43,7 @@ echo "Executing command..."
 echo ""
 
 # save command to file, execute the command from file, remove the file
-echo $response | jq '.choices[0].message.content' | sed -e 's/^.//' -e 's/.$//' > ".tempplscmd"
+echo $command > ".tempplscmd"
 echo -e -n "\033[0;34m" # set color to blue
 source ".tempplscmd"
 cd $cwd


### PR DESCRIPTION
This is ridiculous and I genuinely love it! I've been testing it out all day.

I've found one issue, to do with escaping quotations.

### Problem
Input:
```sh
$ pls tell me how many commits were made in the past month
```

Parsed command:
```sh
git log --oneline --since=\"1 month ago\" | wc -l
```

This command needs to be:
```sh
git log --oneline --since="1 month ago" | wc -l
```

### Solution
Using the `jq` option `--raw-output / -r`. From the [online manual](https://stedolan.github.io/jq/manual/):
> With this option, if the filter's result is a string then it will be written directly to standard output rather than being formatted as a JSON string with quotes.

I've also DRYed up the code a bit, so that it only parses it once.

Thanks for the great tool!