### PR TITLE
Bash globbing: use the 'set' command to temporarily disable this

### DIFF
--- a/pls
+++ b/pls
@@ -3,6 +3,9 @@
 # add your openai api key here
 token="sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
+# disable globbing, to prevent OpenAI's command from being prematurely expanded
+set -f
+
 # get user cli arguments as a string
 args=$*
 
@@ -42,9 +45,12 @@ echo $REPLY
 echo "Executing command..."
 echo ""
 
-# save command to file, execute the command from file, remove the file
-echo $command > ".tempplscmd"
+# re-enable globbing
+set +f
+
+# execute the command
 echo -e -n "\033[0;34m" # set color to blue
-source ".tempplscmd"
+eval "$command"
+
+# navigate back to the original working directory
 cd $cwd
-rm ".tempplscmd"


### PR DESCRIPTION
Another little error I encountered.

#### Problem
Input:
```sh
$ pls list each image and their dimensions
```

Parsed command:
```sh
identify -format '%f %wx%h\n' curtains.svg heatmap.png it_77 (copy).jpg
```

This command needs to be:
```sh
identify -format '%f %wx%h\n' *
```

#### Solution
These 3 files were the images in my directory, so I was a little bit paranoid that OpenAI seemed to know what they were!

Just a case of premature expansion. Not a problem with files that don't have whitespace, but my file "it_77 (copy).jpg" was being incorrectly parsed. Solution is to just use `set -f` to turn this off. (And then `set +f` to turn it back on, though I'm not certain that's actually necessary)