### PR TITLE
Adding macOS support to `os` variable

### DIFF
--- a/pls
+++ b/pls
@@ -17,7 +17,15 @@ args=$*
 cwd=$(pwd)
 
 # save os name to a variable
-os=$(cat /etc/*-release | grep "NAME" -m 1 | cut -d "=" -f 2 | sed 's/"//g' | tr ' ' '_')
+os=$(
+  if [ -f /etc/os-release ]; then
+    cat /etc/*-release | grep "NAME" -m 1 | cut -d "=" -f 2 | sed 's/"//g' | tr ' ' '_'
+  elif [ "$(uname -s)" = "Darwin" ]; then
+    sw_vers -productName
+  else
+    echo "unknown"
+  fi
+)
 
 # disable globbing, to prevent OpenAI's command from being prematurely expanded
 set -f


### PR DESCRIPTION
When executing the script from macOS, it now fails at the line

```
os=$(cat /etc/*-release | grep "NAME" -m 1 | cut -d "=" -f 2 | sed 's/"//g' | tr ' ' '_')
```


This command is suitable for getting a formatted operating system name from Linux-based systems, where the name is in the /etc/*-release files, without spaces and quotes. However, it won't work on non-Linux systems like macOS (or Windows but I'm unable test that)

My fix provides the operating system name, using:

```
sw_vers -productName
```

This will return the product name of the OS, such as "macOS" or "OS X", depending on the version running.

Thanks!

